### PR TITLE
Add addresses for 0.29.2

### DIFF
--- a/dsda-doom.asl
+++ b/dsda-doom.asl
@@ -1,3 +1,12 @@
+state("dsda-doom", "0.29.2") {
+    int gametic: 0xB11070;
+    int gamestate: 0x88BE90;
+    int map: 0x987800;
+    int attempt: 0x970B88;
+    int isMenuOpen: 0xB32C2C;
+    int isDemoPlaying: 0xB35144;
+}
+
 state("dsda-doom", "0.29.0") {
     int gametic: 0x97EF70;
     int gamestate: 0x732590;


### PR DESCRIPTION
This PR adds support for the latest minor release - 0.29.2 - which added demo rewind and is likely to enter common usage. 0.29.1 is not worth supporting since it contains a big crash-to-desktop bug.