### PR TITLE
Add addresses for 0.29.3

### DIFF
--- a/dsda-doom.asl
+++ b/dsda-doom.asl
@@ -1,10 +1,10 @@
-state("dsda-doom", "0.29.2") {
-    int gametic: 0xB11070;
+state("dsda-doom", "0.29.3") {
+    int gametic: 0xB11090;
     int gamestate: 0x88BE90;
-    int map: 0x987800;
+    int map: 0xB34F40;
     int attempt: 0x970B88;
-    int isMenuOpen: 0xB32C2C;
-    int isDemoPlaying: 0xB35144;
+    int isMenuOpen: 0xB32C4C;
+    int isDemoPlaying: 0xB35164;
 }
 
 state("dsda-doom", "0.29.0") {


### PR DESCRIPTION
This PR adds support for the latest minor release - 0.29.3. 0.29.2 contained a bug that deletes people's save files (reported by ZeroMaster) so I think we can drop support.